### PR TITLE
Away and stay exit delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 * `Port`:  Qolsys Panel Port number (defaults to 12345)
 * `Secure Token`: C4 Integration Secure Token 
 * `User Pin Code`: User security code
-* `Arming Exit Delay`: How much time users have to exit the location before the panel arms itself
+* `Arm Away Exit Delay`: How much time users have to exit the location before the panel arms itself to Arm Away (0 sec or any number higher then your panel long exit delay (120 sec by default))
+* `Arm Stay Exit Delay`: How much time before the panel arms itself to Arm Stay (0 sec or any number higher then your panel long exit delay (120 sec by default))
 * `Force Arm`: Bypass open or faulted sensors when arming partition
 
 ## Qolsys Panel Configuration

--- a/config.schema.json
+++ b/config.schema.json
@@ -40,11 +40,17 @@
         "required": true,
         "default": true
       },
-      "ExitDelay":{
-        "title":"Arming Exit Delay",
+      "AwayExitDelay":{
+        "title":"Arm Away Exit Delay",
         "type": "integer",
         "required": true,
-        "default": 60
+        "default": 120
+      },
+      "HomeExitDelay":{
+        "title":"Arm Stay Exit Delay",
+        "type": "integer",
+        "required": true,
+        "default": 120
       },
       "ShowSecurityPanel":{
         "type": "boolean",
@@ -137,7 +143,14 @@
           "expandable": true,
           "expanded": true,
           "items": [
-            "ExitDelay",
+            {
+              "type": "flex",
+              "flex-flow": "row wrap",
+              "items": [
+                "AwayExitDelay",
+                "HomeExitDelay"
+              ]
+            },
             "ForceArm"
           ]
         },

--- a/src/HKSecurityPanel.ts
+++ b/src/HKSecurityPanel.ts
@@ -22,6 +22,25 @@ export class HKSecurityPanel {
     this.service = this.accessory.getService(this.platform.Service.SecuritySystem)
     || this.accessory.addService(this.platform.Service.SecuritySystem);
 
+    const ValidCurrentStates = [
+      this.platform.api.hap.Characteristic.SecuritySystemCurrentState.STAY_ARM,
+      this.platform.api.hap.Characteristic.SecuritySystemCurrentState.AWAY_ARM,
+      this.platform.api.hap.Characteristic.SecuritySystemCurrentState.DISARMED,
+      this.platform.api.hap.Characteristic.SecuritySystemCurrentState.ALARM_TRIGGERED,
+    ];
+
+    const ValidTargetStates = [
+      this.platform.api.hap.Characteristic.SecuritySystemTargetState.STAY_ARM,
+      this.platform.api.hap.Characteristic.SecuritySystemTargetState.AWAY_ARM,
+      this.platform.api.hap.Characteristic.SecuritySystemTargetState.DISARM,
+    ];
+
+    this.service.getCharacteristic(this.platform.api.hap.Characteristic.SecuritySystemCurrentState)
+      .setProps({ validValues: ValidCurrentStates});
+
+    this.service.getCharacteristic(this.platform.api.hap.Characteristic.SecuritySystemTargetState)
+      .setProps({ validValues: ValidTargetStates });
+
     this.service.getCharacteristic(this.platform.Characteristic.SecuritySystemTargetState)
       .onSet(this.handleSecuritySystemTargetStateSet.bind(this));
 
@@ -53,9 +72,9 @@ export class HKSecurityPanel {
       }
 
       case this.platform.Characteristic.SecuritySystemTargetState.AWAY_ARM:{
-        const ExitDelay = this.platform.ExitDelay;
+        const AwayExitDelay = this.platform.AwayExitDelay;
         const Bypass = this.platform.ForceArm;
-        this.platform.Controller.SendArmCommand(QolsysAlarmMode.ARM_AWAY, this.PartitionId, ExitDelay, Bypass);
+        this.platform.Controller.SendArmCommand(QolsysAlarmMode.ARM_AWAY, this.PartitionId, AwayExitDelay, Bypass);
         break;
       }
 
@@ -66,9 +85,9 @@ export class HKSecurityPanel {
       }
 
       case this.platform.Characteristic.SecuritySystemTargetState.STAY_ARM:{
-        const ExitDelay = this.platform.ExitDelay;
+        const HomeExitDelay = this.platform.HomeExitDelay;
         const Bypass = this.platform.ForceArm;
-        this.platform.Controller.SendArmCommand(QolsysAlarmMode.ARM_STAY, this.PartitionId, ExitDelay, Bypass);
+        this.platform.Controller.SendArmCommand(QolsysAlarmMode.ARM_STAY, this.PartitionId, HomeExitDelay, Bypass);
         break;
       }
     }
@@ -77,10 +96,16 @@ export class HKSecurityPanel {
   private QolsysPartitionStatusToCurrentHKStatus(Status: QolsysAlarmMode){
     switch(Status){
       case QolsysAlarmMode.EXIT_DELAY:
-        return this.platform.Characteristic.SecuritySystemCurrentState.AWAY_ARM;
+        return this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
 
       case QolsysAlarmMode.ENTRY_DELAY:
         return this.platform.Characteristic.SecuritySystemCurrentState.AWAY_ARM;
+
+      case QolsysAlarmMode.ARM_STAY_EXIT_DELAY:
+        return this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
+
+      case QolsysAlarmMode.ARM_AWAY_EXIT_DELAY:
+        return this.platform.Characteristic.SecuritySystemCurrentState.DISARMED;
 
       case QolsysAlarmMode.ARM_AWAY:
         return this.platform.Characteristic.SecuritySystemCurrentState.AWAY_ARM;
@@ -111,6 +136,12 @@ export class HKSecurityPanel {
         return this.platform.Characteristic.SecuritySystemTargetState.AWAY_ARM;
 
       case QolsysAlarmMode.ENTRY_DELAY:
+        return this.platform.Characteristic.SecuritySystemTargetState.DISARM;
+
+      case QolsysAlarmMode.ARM_STAY_EXIT_DELAY:
+        return this.platform.Characteristic.SecuritySystemTargetState.STAY_ARM;
+
+      case QolsysAlarmMode.ARM_AWAY_EXIT_DELAY:
         return this.platform.Characteristic.SecuritySystemTargetState.AWAY_ARM;
 
       case QolsysAlarmMode.ARM_AWAY:

--- a/src/QolsysController.ts
+++ b/src/QolsysController.ts
@@ -173,6 +173,7 @@ export class QolsysController extends TypedEmitter<QolsysControllerEvent> {
     }
 
     private Refresh(){
+      console.log('refresh');
       const CommandJSON = {
         nonce: '',
         action: 'INFO',
@@ -189,7 +190,7 @@ export class QolsysController extends TypedEmitter<QolsysControllerEvent> {
 
       let FormattedMessage:string = Message.replace(/[^\x20-\x7E]+/g, '');
 
-      if(FormattedMessage.length >= 3 && FormattedMessage.substring(0.3) === 'ACK'){
+      if(FormattedMessage === 'ACK'){
         this.PartialMessage = '';
         this.emit('PrintDebugInfo', 'Received: ' + FormattedMessage);
       } else{
@@ -426,6 +427,13 @@ export class QolsysController extends TypedEmitter<QolsysControllerEvent> {
       const Partition = this.Partitions[PartitionId];
       if(Partition!== undefined){
         if(Partition.SetAlarmMode(AlarmMode)){
+
+          // If Exit_Delay, need to run a new refresh to access ARM-AWAY-EXIT-DELAY vs ARM-STAY-EXIT-DELAY
+          if(Partition.PartitionStatus === QolsysAlarmMode.EXIT_DELAY){
+            this.Refresh();
+            return;
+          }
+
           if(this.PanelReadyForOperation && this.PanelReceivingNotifcation){
             this.emit('PartitionAlarmModeChange', Partition);
           }
@@ -452,7 +460,9 @@ export class QolsysController extends TypedEmitter<QolsysControllerEvent> {
         Partition.PartitionName = Name;
         Partition.SecureArm = SecureArm;
 
+
         if(Partition.SetAlarmModeFromString(Status) && this.PanelReadyForOperation || this.InitialRun){
+          console.log(Partition);
           this.emit('PartitionAlarmModeChange', Partition);
         }
 

--- a/src/QolsysPartition.ts
+++ b/src/QolsysPartition.ts
@@ -1,6 +1,8 @@
 export enum QolsysAlarmMode{
   DISARM = 'DISARM',
   ENTRY_DELAY = 'ENTRY_DELAY',
+  ARM_STAY_EXIT_DELAY = 'ARM_STAY_EXIT_DELAY',
+  ARM_AWAY_EXIT_DELAY = 'ARM_AWAY_EXIT_DELAY',
   EXIT_DELAY ='EXIT_DELAY',
   ARM_AWAY = 'ARM_AWAY',
   ARM_STAY = 'ARM_STAY',
@@ -65,6 +67,12 @@ export class QolsysPartition{
 
         case 'ALARM_AUXILIARY':
           return this.SetAlarmMode(QolsysAlarmMode.ALARM_AUXILIARY);
+
+        case 'ARM-STAY-EXIT-DELAY':
+          return this.SetAlarmMode(QolsysAlarmMode.ARM_STAY_EXIT_DELAY);
+
+        case 'ARM-AWAY-EXIT-DELAY':
+          return this.SetAlarmMode(QolsysAlarmMode.ARM_AWAY_EXIT_DELAY);
 
         default:
           return this.SetAlarmMode(QolsysAlarmMode.Unknow);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -49,7 +49,8 @@ export class HBQolsysPanel implements DynamicPlatformPlugin {
   private LogZone = false;
   private LogDebug = false;
   ForceArm = true;
-  ExitDelay = 60;
+  AwayExitDelay = 120;
+  HomeExitDelay = 120;
 
   constructor(
     public readonly log: Logger,
@@ -155,8 +156,12 @@ export class HBQolsysPanel implements DynamicPlatformPlugin {
       this.ForceArm = this.config.ForceArm;
     }
 
-    if(this.config.ExitDelay !== undefined){
-      this.ExitDelay = this.config.ExitDelay;
+    if(this.config.AwayExitDelay !== undefined){
+      this.AwayExitDelay = this.config.AwayExitDelay;
+    }
+
+    if(this.config.HomeExitDelay !== undefined){
+      this.HomeExitDelay = this.config.HomeExitDelay;
     }
 
     this.PanelHost = Host;


### PR DESCRIPTION
- Removing HomeKit Security Panel Night Mode (No night mode available on Qolsys panels)
- Adding Away-Exit-Delay and Stay-Exit-Delay states