### PR TITLE
Motion sensor minimun trigger duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This plugin only supports the IQ Panel basic security features:
 * `Arm Away Exit Delay`: How much time users have to exit the location before the panel arms itself to Arm Away (0 sec or any number higher than your panel long exit delay (120 sec by default))
 * `Arm Stay Exit Delay`: How much time before the panel arms itself to Arm Stay (0 sec or any number higher than your panel long exit delay (120 sec by default))
 * `Force Arm`: Bypass open or faulted sensors when arming partition
+* `Sensor minimum trigger duration`: Some sensors are instantaneously reverting to a closed status after being brought in an open state. This option will introduce a small delay to make sure the event was properly registered by Homekit in Home App.  
 
 ## Qolsys Panel Configuration
 ### IQ2, IQ2+ and IQ4

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin only supports the IQ Panel basic security features:
 | [IQ HUB](https://qolsys.com/iq4-hub/) |Not Supported |  |
 | [IQ2](https://qolsys.com/iq-panel-2/) | Supported | Software >= 2.4.0 |
 | [IQ2+](https://qolsys.com/iq-panel-2-plus/) | Supported| For software >= 2.6.2: Enable 6-digit user codes |
-| [IQ4](https://qolsys.com/iq-panel-4/) |Status Pending | Software >= 4.1.0 |
+| [IQ4](https://qolsys.com/iq-panel-4/) | Supported | Software >= 4.1.0 |
 | [IQ4 HUB](https://qolsys.com/iq4-hub/) | Status Pending |  |
 
 ## Supported Sensors

--- a/config.schema.json
+++ b/config.schema.json
@@ -111,6 +111,11 @@
         "type": "boolean",
         "title": "Show Qolsys panel debug information",
         "default": false
+      },
+      "SensorDelay":{
+        "type": "boolean",
+        "title": "Sensor minimum trigger duration",
+        "default": false
       }
     }
   },
@@ -180,6 +185,15 @@
             "LogPartition",
             "LogZone",
             "LogDebug"
+          ]
+        },
+        {
+          "title": "Experimental Options",
+          "type": "fieldset",
+          "expandable": true,
+          "expanded": true,
+          "items": [
+            "SensorDelay"
           ]
         }]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-qolsys",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-qolsys",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "tiny-typed-emitter": "^2.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-qolsys",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-qolsys",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "tiny-typed-emitter": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Qolsys Panel",
   "name": "homebridge-qolsys",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Homebridge plugin for Qolsys Panel.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Qolsys Panel",
   "name": "homebridge-qolsys",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Homebridge plugin for Qolsys Panel.",
   "license": "MIT",
   "repository": {

--- a/src/HKCOSensor.ts
+++ b/src/HKCOSensor.ts
@@ -32,6 +32,7 @@ export class HKCOSensor extends HKSensor {
 
     setTimeout(() => {
       this.service.updateCharacteristic(this.platform.Characteristic.CarbonMonoxideDetected, CODetected );
+      this.LastEvent = new Date();
     }, this.EventDelayNeeded());
   }
 }

--- a/src/HKCOSensor.ts
+++ b/src/HKCOSensor.ts
@@ -15,7 +15,7 @@ export class HKCOSensor extends HKSensor {
 
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Qolsys Panel')
-      .setCharacteristic(this.platform.Characteristic.Model, 'HK CO2 Sensor')
+      .setCharacteristic(this.platform.Characteristic.Model, 'HK CO Sensor')
       .setCharacteristic(this.platform.Characteristic.SerialNumber, 'QolsysZone' + ZoneId);
 
     this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
@@ -29,6 +29,9 @@ export class HKCOSensor extends HKSensor {
   HandleEventDetected(ZoneStatus: QolsysZoneStatus){
 
     const CODetected = ZoneStatus === QolsysZoneStatus.OPEN;
-    this.service.updateCharacteristic(this.platform.Characteristic.CarbonMonoxideDetected, CODetected );
+
+    setTimeout(() => {
+      this.service.updateCharacteristic(this.platform.Characteristic.CarbonMonoxideDetected, CODetected );
+    }, this.EventDelayNeeded());
   }
 }

--- a/src/HKContactSensor.ts
+++ b/src/HKContactSensor.ts
@@ -33,11 +33,16 @@ export class HKContactSensor extends HKSensor {
     const ContactDetected = ZoneStatus === QolsysZoneStatus.CLOSED;
 
     if(ContactDetected){
-      this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState)
-        .updateValue(this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED);
+      setTimeout(() => {
+        this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState)
+          .updateValue(this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED);
+      }, this.EventDelayNeeded());
+
     } else{
-      this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState)
-        .updateValue(this.platform.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
+      setTimeout(() => {
+        this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState)
+          .updateValue(this.platform.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
+      }, this.EventDelayNeeded());
     }
   }
 }

--- a/src/HKContactSensor.ts
+++ b/src/HKContactSensor.ts
@@ -36,12 +36,16 @@ export class HKContactSensor extends HKSensor {
       setTimeout(() => {
         this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState)
           .updateValue(this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED);
+        this.LastEvent = new Date();
+
       }, this.EventDelayNeeded());
 
     } else{
       setTimeout(() => {
         this.service.getCharacteristic(this.platform.Characteristic.ContactSensorState)
           .updateValue(this.platform.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED);
+        this.LastEvent = new Date();
+
       }, this.EventDelayNeeded());
     }
   }

--- a/src/HKLeakSensor.ts
+++ b/src/HKLeakSensor.ts
@@ -32,6 +32,7 @@ export class HKLeakSensor extends HKSensor {
 
     setTimeout(() => {
       this.service.updateCharacteristic(this.platform.Characteristic.LeakDetected, LeakDetected);
+      this.LastEvent = new Date();
     }, this.EventDelayNeeded());
   }
 }

--- a/src/HKLeakSensor.ts
+++ b/src/HKLeakSensor.ts
@@ -29,6 +29,9 @@ export class HKLeakSensor extends HKSensor {
 
   HandleEventDetected(ZoneStatus: QolsysZoneStatus){
     const LeakDetected = ZoneStatus === QolsysZoneStatus.OPEN;
-    this.service.updateCharacteristic(this.platform.Characteristic.LeakDetected, LeakDetected);
+
+    setTimeout(() => {
+      this.service.updateCharacteristic(this.platform.Characteristic.LeakDetected, LeakDetected);
+    }, this.EventDelayNeeded());
   }
 }

--- a/src/HKMotionSensor.ts
+++ b/src/HKMotionSensor.ts
@@ -28,7 +28,20 @@ export class HKMotionSensor extends HKSensor {
   }
 
   HandleEventDetected(ZoneStatus: QolsysZoneStatus){
+
+    const CurrentStatus = this.service.getCharacteristic(this.platform.Characteristic.MotionDetected);
     const MotionDetected = (ZoneStatus === QolsysZoneStatus.OPEN);
-    this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
+
+
+    if(CurrentStatus && !MotionDetected){
+      setTimeout(() => {
+        this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
+      }, 2000);
+    }
+    else{
+      this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
+    }
+
+
   }
 }

--- a/src/HKMotionSensor.ts
+++ b/src/HKMotionSensor.ts
@@ -37,8 +37,7 @@ export class HKMotionSensor extends HKSensor {
       setTimeout(() => {
         this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
       }, 2000);
-    }
-    else{
+    } else{
       this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
     }
 

--- a/src/HKMotionSensor.ts
+++ b/src/HKMotionSensor.ts
@@ -33,6 +33,7 @@ export class HKMotionSensor extends HKSensor {
 
     setTimeout(() => {
       this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
+      this.LastEvent = new Date();
     }, this.EventDelayNeeded());
   }
 

--- a/src/HKMotionSensor.ts
+++ b/src/HKMotionSensor.ts
@@ -29,18 +29,11 @@ export class HKMotionSensor extends HKSensor {
 
   HandleEventDetected(ZoneStatus: QolsysZoneStatus){
 
-    const CurrentStatus = this.service.getCharacteristic(this.platform.Characteristic.MotionDetected);
     const MotionDetected = (ZoneStatus === QolsysZoneStatus.OPEN);
 
-
-    if(CurrentStatus && !MotionDetected){
-      setTimeout(() => {
-        this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
-      }, 2000);
-    } else{
+    setTimeout(() => {
       this.service.updateCharacteristic(this.platform.Characteristic.MotionDetected, MotionDetected );
-    }
-
-
+    }, this.EventDelayNeeded());
   }
+
 }

--- a/src/HKSecurityPanel.ts
+++ b/src/HKSecurityPanel.ts
@@ -15,7 +15,7 @@ export class HKSecurityPanel {
 
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Qolsys')
-      .setCharacteristic(this.platform.Characteristic.Model, 'Qolsys Panel')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Qolsys IQ Panel')
       .setCharacteristic(this.platform.Characteristic.SerialNumber, 'QolsysPanel' + this.PartitionId)
       .setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
 

--- a/src/HKSensor.ts
+++ b/src/HKSensor.ts
@@ -25,15 +25,18 @@ export abstract class HKSensor {
   protected EventDelayNeeded():number{
 
     if(!this.platform.SensorDelay){
+      this.platform.log.debug('No delay to Homekit');
       return 0;
     }
 
     const Delta = new Date().getTime() - this.LastEvent.getTime();
 
     if(Delta < 1000){
+      this.platform.log.debug('Introducing 2 sec delay to Homekit');
       return 2000;
     }
 
+    this.platform.log.debug('No delay to Homekit');
     return 0;
   }
 }

--- a/src/HKSensor.ts
+++ b/src/HKSensor.ts
@@ -4,6 +4,7 @@ import { HKSensorType, HBQolsysPanel} from './platform';
 
 export abstract class HKSensor {
   protected service: Service;
+  protected LastEvent: Date;
 
   constructor(
     protected readonly platform: HBQolsysPanel,
@@ -15,8 +16,24 @@ export abstract class HKSensor {
     this.SensorType = SensorType;
     this.service = this.GetService();
     this.platform.log.info('Zone'+ this.ZoneId + ' (' + SensorType + '): ' + accessory.displayName);
+    this.LastEvent = new Date();
   }
 
   abstract GetService(): Service;
   abstract HandleEventDetected(ZoneStatus: QolsysZoneStatus);
+
+  protected EventDelayNeeded():number{
+
+    if(!this.platform.SensorDelay){
+      return 0;
+    }
+
+    const Delta = new Date().getTime() - this.LastEvent.getTime();
+
+    if(Delta < 1000){
+      return 2000;
+    }
+
+    return 0;
+  }
 }

--- a/src/HKSmokeSensor.ts
+++ b/src/HKSmokeSensor.ts
@@ -30,11 +30,15 @@ export class HKSmokeSensor extends HKSensor {
     const SmokeDetected = ZoneStatus === QolsysZoneStatus.OPEN;
 
     if(SmokeDetected){
-      this.service.updateCharacteristic(this.platform.Characteristic.SmokeDetected,
-        this.platform.Characteristic.SmokeDetected.SMOKE_DETECTED);
+      setTimeout(() => {
+        this.service.updateCharacteristic(this.platform.Characteristic.SmokeDetected,
+          this.platform.Characteristic.SmokeDetected.SMOKE_DETECTED);
+      }, this.EventDelayNeeded());
     } else{
-      this.service.updateCharacteristic(this.platform.Characteristic.SmokeDetected,
-        this.platform.Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
+      setTimeout(() => {
+        this.service.updateCharacteristic(this.platform.Characteristic.SmokeDetected,
+          this.platform.Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
+      }, this.EventDelayNeeded());
     }
   }
 }

--- a/src/HKSmokeSensor.ts
+++ b/src/HKSmokeSensor.ts
@@ -33,11 +33,13 @@ export class HKSmokeSensor extends HKSensor {
       setTimeout(() => {
         this.service.updateCharacteristic(this.platform.Characteristic.SmokeDetected,
           this.platform.Characteristic.SmokeDetected.SMOKE_DETECTED);
+        this.LastEvent = new Date();
       }, this.EventDelayNeeded());
     } else{
       setTimeout(() => {
         this.service.updateCharacteristic(this.platform.Characteristic.SmokeDetected,
           this.platform.Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
+        this.LastEvent = new Date();
       }, this.EventDelayNeeded());
     }
   }

--- a/src/QolsysController.ts
+++ b/src/QolsysController.ts
@@ -425,15 +425,16 @@ export class QolsysController extends TypedEmitter<QolsysControllerEvent> {
     private ProcessArmingType(PartitionId:number, AlarmMode:QolsysAlarmMode){
       const Partition = this.Partitions[PartitionId];
       if(Partition!== undefined){
+
+        if(Partition.PartitionStatus === QolsysAlarmMode.ENTRY_DELAY){
+          this.Refresh();
+          return;
+        }
+
         if(Partition.SetAlarmMode(AlarmMode)){
 
           // If Exit_Delay, need to run a new refresh to access ARM-AWAY-EXIT-DELAY vs ARM-STAY-EXIT-DELAY
           if(Partition.PartitionStatus === QolsysAlarmMode.EXIT_DELAY){
-            this.Refresh();
-            return;
-          }
-
-          if(Partition.PartitionStatus === QolsysAlarmMode.ENTRY_DELAY){
             this.Refresh();
             return;
           }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -48,9 +48,12 @@ export class HBQolsysPanel implements DynamicPlatformPlugin {
   private LogPartition = true;
   private LogZone = false;
   private LogDebug = false;
+
   ForceArm = true;
   AwayExitDelay = 120;
   HomeExitDelay = 120;
+  SensorDelay = false;
+
 
   constructor(
     public readonly log: Logger,
@@ -162,6 +165,10 @@ export class HBQolsysPanel implements DynamicPlatformPlugin {
 
     if(this.config.HomeExitDelay !== undefined){
       this.HomeExitDelay = this.config.HomeExitDelay;
+    }
+
+    if(this.config.SensorDelay !== undefined){
+      this.SensorDelay = this.config.SensorDelay;
     }
 
     this.PanelHost = Host;


### PR DESCRIPTION
Some sensors will instantaneously revert back to a closed stated after detecting an event (IQ Motion for example).
CLOSE -> OPEN -> CLOSE (in the same second)

While Homekit will fire automations based on that detected event, Home App will possibely not show the accessory as being active and will not show activity notifications associated with that accessory.

With the Experimental Option `Sensor minimum trigger duration` enabled, the plugin will detect fast and instantaneously transitions between sensors states and introduce a small delay to allow for event to be properly shown in Home App (Accessory activity and notification).